### PR TITLE
Add missing modules to list

### DIFF
--- a/release.p6
+++ b/release.p6
@@ -1,4 +1,4 @@
-my constant @distros = 'cro-core', 'cro-tls', 'cro-http', 'cro-websocket', 'cro-zeromq', 'cro', 'cro-http-test', 'cro-http-session-redis';
+my constant @distros = 'cro-core', 'cro-tls', 'cro-http', 'cro-websocket', 'cro-zeromq', 'cro', 'cro-http-session-redis';
 
 sub MAIN(Str $version where /^\d+'.'\d+['.'\d+]?$/) {
     for @distros {

--- a/release.p6
+++ b/release.p6
@@ -1,4 +1,4 @@
-my constant @distros = 'cro-core', 'cro-tls', 'cro-http', 'cro-websocket', 'cro-zeromq', 'cro';
+my constant @distros = 'cro-core', 'cro-tls', 'cro-http', 'cro-websocket', 'cro-zeromq', 'cro', 'cro-http-test', 'cro-http-session-redis';
 
 sub MAIN(Str $version where /^\d+'.'\d+['.'\d+]?$/) {
     for @distros {


### PR DESCRIPTION
Those were omitted before and started to get behind whole cro versioning as we introduced this release script, so with adding those two modules in processing list we get automatic version bump for it, hence keeping version for all modules consistent.