### PR TITLE
Update release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 How to do a release
 ===================
 
-- Change the version numbers in `versions.json` to the versions you want to
-  release. Keep the versions of modules you don't want to release unchanged.
-- Run `release.raku --prepare` in a folder containing clones of all of the
-  Cro distros:
+- Have all of the 6 core Cro projects
   - cro-core
   - cro-tls
   - cro-http
   - cro-websocket
   - cro-webapp
   - cro
+  as well as the website (cro-website) checked out in a folder.
+- Ensure the `fez` program is available and you are logged in and are a member
+  of the `cro` org.
+- Ensure all the clones of each project have a remote called `origin` that
+  allows writes.
+- Change the version numbers in `versions.json` to the versions you want to
+  release. Keep the versions of modules you don't want to release unchanged.
+- Run `release.raku --prepare` in the parent folder of of the above mentioned
+  repos.
   This will then automatically do the following:
   - `git pull` in all the repos
   - Create a commit and push in `cro` that bumps the OCI image version.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,27 @@ How to do a release
 
 - Change the version numbers in `versions.json` to the versions you want to
   release. Keep the versions of modules you don't want to release unchanged.
-- Run `release.raku --prepare`. This will do a release in all modules that have
-  a changed version number.
-- Complete the pre-generated release notes in `cro-website/docs/releases.md`
-  commit / push / release those.
+- Run `release.raku --prepare` in a folder containing clones of all of the
+  Cro distros:
+  - cro-core
+  - cro-tls
+  - cro-http
+  - cro-websocket
+  - cro-webapp
+  - cro
+  This will then automatically do the following:
+  - `git pull` in all the repos
+  - Create a commit and push in `cro` that bumps the OCI image version.
+  - For each distro that has a changed version number in `versions.json`:
+    - Update the `version` and `api` in `META6.json`.
+    - Update all the `depends` versions of the other Cro distros in
+      `META6.json`.
+    - Update the version in the `Changes` file.
+    - Create a commit and push.
+  - Create and push a release tag in all updated distros.
+  - Add a skeleton release announcement section to
+    `cro-website/docs/releases.md`.
+- Complete the pre-generated release notes in `cro-website/docs/releases.md`.
+- Commit, push and publish the release announcement.
+- Commit and push the changes to the `versions.json` file.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+How to do a release
+===================
+
+- Change the version numbers in `versions.json` to the versions you want to
+  release. Keep the versions of modules you don't want to release unchanged.
+- Run `release.raku --prepare`. This will do a release in all modules that have
+  a changed version number.
+- Complete the pre-generated release notes in `cro-website/docs/releases.md`
+  commit / push / release those.
+

--- a/release.raku
+++ b/release.raku
@@ -63,8 +63,9 @@ multi MAIN(:$prepare!) {
         tag($dir, "release-$version");
         say "* $_";
     }
-    prepare-announcement(@bumped-distros, %versions);
 
+    say "Creating an announcement template";
+    prepare-announcement(@bumped-distros, %versions);
 
     # Release
     say "Uploading to zef ecosystem";
@@ -131,7 +132,14 @@ sub prepare-announcement(@bumped-distros, %versions) {
                .subst('{{DISTROS}}', $distros-text);
 
     my $releases = slurp($file);
-    $releases ~~ s/ "# Cro Release History" \n \n /$/$text\n/;
+
+    if $releases ~~ / "# Cro Release History" \n \n / {
+        $releases ~~ s/ "# Cro Release History" \n \n /$/$text\n/;
+    }
+    else {
+        note "Could not find \"# Cro Release History\" in $file, just spurting the announcement at the top.";
+        $releases ~~ s/ ^ /$text\n/;
+    }
     spurt $file, $releases;
 }
 

--- a/release.raku
+++ b/release.raku
@@ -126,7 +126,7 @@ sub prepare-announcement(@bumped-distros, %versions) {
     }).join("\n\n");
 
     my $versions-text = @distros.map({
-        $_
+        "- " ~ $_
         ~ ':ver<' ~ %versions<distros>{$_} ~ '>'
         ~ ':api<' ~ %versions<api> ~ '>' ~
         ~ ':auth<zef:cro>'

--- a/release.raku
+++ b/release.raku
@@ -72,6 +72,9 @@ multi MAIN(:$prepare!) {
     for @bumped-distros {
         my $dir = %distro-dirs{$_};
         say "# $_";
+        do {
+            shell "cd $dir && fez review";
+        } while prompt("Does this look sane? [yn]") ne "y";
         shell "cd $dir && fez upload";
     }
 }

--- a/release.raku
+++ b/release.raku
@@ -1,24 +1,43 @@
 use JSON::Fast;
 
-my constant @distros = 'cro-core', 'cro-tls', 'cro-http', 'cro-websocket',
-                       'cro-webapp', 'cro';
+my constant @distros = 'Cro::Core',
+                       'Cro::HTTP',
+                       'Cro::TLS',
+                       'Cro::WebApp',
+                       'Cro::WebSocket',
+                       'cro';
+my constant %distro-dirs = 'Cro::Core' => 'cro-core',
+                           'Cro::TLS' => 'cro-tls',
+                           'Cro::HTTP' => 'cro-http',
+                           'Cro::WebSocket' => 'cro-websocket',
+                           'Cro::WebApp' => 'cro-webapp',
+                           'cro' => 'cro';
 
 multi MAIN(:$clean!) {
-    shell "rm -rf $_" if .IO.d for @distros;
+    shell "rm -rf $_" if .IO.d for %distro-dirs.values;
+}
+
+multi MAIN(:$reset!) {
+    shell "cd $_ && git reset --hard HEAD" if .IO.d for %distro-dirs.values;
 }
 
 multi MAIN(:$get!) {
-    shell "git clone git@github.com:/croservices/$_.git" unless .IO.d for @distros;
+    shell "git clone git@github.com:/croservices/$_.git" unless .IO.d for %distro-dirs.values;
 }
 
-multi MAIN(Str $version where /^\d+'.'\d+['.'\d+]?$/) {
-    for @distros {
+multi MAIN(:$prepare!) {
+    # Change versioning scheme.
+    # Generate release log template from Changes files and committers.
+
+    my $versions = from-json $*PROGRAM.parent.add("versions.json").slurp;
+
+    for %distro-dirs.values {
         unless .IO.d {
             conk "Missing directory '$_' (script expects Cro repos checked out in CWD)";
         }
     }
 
-    for @distros {
+    for %distro-dirs.values {
         check-clean-diff($_);
         pull($_);
     }
@@ -27,8 +46,11 @@ multi MAIN(Str $version where /^\d+'.'\d+['.'\d+]?$/) {
     bump-docker-image-version($version);
 
     # Bump versions and commit bumps.
-    for @distros {
-        bump-version($_, $version);
+    my @bumped-distros;
+    for @distros -> $name {
+        my $dir = %distro-dirs{$name};
+        my $bumped = bump-version($dir, $name, $versions<distros>, $versions<api>);
+        @bumped-distros.push($name) if $bumped;
     }
 
     # Tag
@@ -37,6 +59,8 @@ multi MAIN(Str $version where /^\d+'.'\d+['.'\d+]?$/) {
         tag($_, "release-$version");
         say "* $_";
     }
+    prepare-announcement(@bumped-distros, $versions);
+
 
     # Release
     say "Uploading to zef ecosystem";
@@ -44,6 +68,66 @@ multi MAIN(Str $version where /^\d+'.'\d+['.'\d+]?$/) {
         say "# $_";
         shell "cd $_ && fez upload";
     }
+}
+
+sub prepare-announcement(@bumped-distros, %versions) {
+    my $template = Q:to/EOT/;
+        ## {{DATE}}
+
+        The latest versions of the Cro libraries are:
+
+        {{VERSIONS}}
+
+        To use the Cro libraries in a project, it usually suffices to only depend on
+        `Cro::HTTP` and optionally `Cro::WebApp` or `Cro::WebSocket`.
+
+        {{DISTROS}}
+        EOT
+
+    my $distro-template = Q:to/EOT/;
+        ### {{NAME}} {{VERSION}}
+
+        {{CHANGES}}
+
+        This release was contributed to by:
+        {{CONTRIBUTORS}}
+        EOT
+
+    my $file = 'cro-website/docs/releases.md';
+
+    my %changes;
+    my $distros-text = @bumped-distros.map(-> $distro {
+        my $dir = %distro-dirs{$distro};
+        my $version = %versions<distros>{$distro};
+        my $changes-file = "$dir/Changes".IO.slurp;
+        do if $changes-file ~~ / ^^ $version [\h <-[ \n ]>*]? \n ( [ <!before \n \S > . ]+ ) / {
+            my $changes = $0.trim-trailing.lines.map(*.substr(4)).join("\n");
+            $distro-template
+                .subst('{{NAME}}', $distro)
+                .subst('{{VERSION}}', $version)
+                .subst('{{CHANGES}}', $changes)
+                .subst('{{CONTRIBUTORS}}', get-committers($dir).sort.join(", "))
+        }
+        else {
+            conk "Missing Changes in $distro";
+        }
+    }).join("\n\n");
+
+    my $versions-text = @distros.map({
+        $_
+        ~ ':ver<' ~ %versions<distros>{$_} ~ '>'
+        ~ ':api<' ~ %versions<api> ~ '>' ~
+        ~ ':auth<zef:cro>'
+    }).join("\n");
+
+    my $text = $template
+               .subst('{{DATE}}', Date.today.Str)
+               .subst('{{VERSIONS}}', $versions-text)
+               .subst('{{DISTROS}}', $distros-text);
+
+    my $releases = slurp($file);
+    $releases ~~ s/ "# Cro Release History" \n \n /$/$text\n/;
+    spurt $file, $releases;
 }
 
 sub bump-docker-image-version($version) {
@@ -58,7 +142,7 @@ sub bump-docker-image-version($version) {
             $version;
         if $updated ~~ /$version/ {
             spurt $file, $updated;
-            shell "cd cro && git commit -m 'Bump docker images to $version' lib/Cro/Tools/Template/Common.rakumod && git push origin master"
+            shell "cd cro && git commit -m 'Bump docker images to $version' lib/Cro/Tools/Template/Common.rakumod && git push origin master";
         }
         else {
             die "Could not find version to update in $file";
@@ -66,47 +150,77 @@ sub bump-docker-image-version($version) {
     }
 }
 
-sub bump-version($distro, $version) {
-    my $file = "$distro/META6.json";
+sub bump-version($distro-dir, $name, %distro-versions, $api-version) {
+    my $file = "$distro-dir/META6.json";
     my $json = slurp $file;
     my $meta = from-json $json;
+    my $my-version = %distro-versions{$name};
     given $meta {
         my $updated;
         # Update the module version itself
-        if $meta<version> eq $version {
-            note "$distro/META6.json already up to date with version number";
+        if $meta<version> eq $my-version {
+            note "$distro-dir/META6.json already up to date with version number";
+            return False;
         } else {
-            $updated = $json.subst(/'"version"' \s* ':' \s* '"' <( <-["]>+ )> '"'/, $version);
+            $updated = $json.subst(/'"version"' \s* ':' \s* '"' <( <-["]>+ )> '"'/, $my-version);
         }
+
+        # Update API version.
+        if $meta<api> ne $api-version {
+            $updated = $json.subst(/'"api"' \s* ':' \s* '"' <( <-["]>+ )> '"'/, $api-version);
+        }
+
         # Next update dependencies
         for @($meta<depends>) -> $module {
             if $module ~~ /('Cro::' \w+)/ {
-                $updated .= subst(/ '"depends"' \s* ':' \s* '[' <-[\]]>*? <( $module )> <-[\]]>*? ']' /, "$0\:ver<$version>");
+                $updated .= subst(/ '"depends"' \s* ':' \s* '[' <-[\]]>*? <( $module )> <-[\]]>*? ']' /, "$0:ver<{ %distro-versions{$0} }+>:api<$api-version>:auth<zef:cro>");
             }
         }
 
-        if $updated ~~ /$version/ {
+        # Update version in Changes
+        my $changes-file = "$distro-dir/Changes";
+        my $changes = $changes-file.IO.slurp;
+        $changes ~~ s/'{{NEXT}}'/$my-version/;
+        spurt $changes-file, $changes;
+
+        if $updated ~~ /$my-version/ {
             spurt $file, $updated;
             shell "cd $distro && git commit -m 'Bump version to $version' META6.json && git push origin master"
         }
         else {
-            conk "Could not find version in $distro/META6.json";
+            conk "Could not find version in $distro-dir/META6.json";
         }
+
+        return True;
+    }
+    return False;
+}
+
+sub check-clean-diff($distro-dir) {
+    if qqx/cd $distro-dir && git diff/ {
+        conk "Dirty working tree in $distro-dir";
     }
 }
 
-sub check-clean-diff($distro) {
-    if qqx/cd $distro && git diff/ {
-        conk "Dirty working tree in $distro";
-    }
+sub pull($distro-dir) {
+    shell "cd $distro-dir && git pull"
 }
 
-sub pull($distro) {
-    shell "cd $distro && git pull"
+sub tag($distro-dir, $tag) {
+    shell "cd $distro-dir && git tag -a -m '$tag' $tag && git push --tags origin";
 }
 
-sub tag($distro, $tag) {
-    shell "cd $distro && git tag -a -m '$tag' $tag && git push --tags origin"
+sub get-latest-release-tag($distro-dir) {
+    my $proc = shell "cd $distro-dir && git tag --list 'release-*' --sort=-v:refname", :out;
+    my $out = $proc.out.slurp: :close;
+    $out.lines[0];
+}
+
+sub get-committers($distro-dir) {
+    my $last-tag = get-latest-release-tag $distro-dir;
+    my $proc = shell "cd $distro-dir && git log --no-merges --pretty=format:\"\%cn\" $last-tag..HEAD", :out;
+    my $out = $proc.out.slurp: :close;
+    $out.lines.unique;
 }
 
 sub conk($err) {

--- a/release.raku
+++ b/release.raku
@@ -33,6 +33,9 @@ multi MAIN(:$prepare!) {
 
     my %versions = from-json $*PROGRAM.parent.add("versions.json").slurp;
 
+    # Check that fez is there.
+    shell "fez";
+
     for %distro-dirs.values {
         unless .IO.d {
             conk "Missing directory '$_' (script expects Cro repos checked out in CWD)";
@@ -201,7 +204,7 @@ sub bump-version($distro-dir, $name, %distro-versions, $api-version) {
 
         if $updated ~~ /$my-version/ {
             spurt $file, $updated;
-            shell "cd $distro-dir && git commit -m 'Bump version to $my-version' META6.json && git push origin main"
+            shell "cd $distro-dir && git commit -m 'Bump version to $my-version' META6.json Changes && git push origin main"
         }
         else {
             conk "Could not find version in $distro-dir/META6.json";

--- a/release.raku
+++ b/release.raku
@@ -237,7 +237,7 @@ sub get-latest-release-tag($distro-dir) {
 
 sub get-committers($distro-dir) {
     my $last-tag = get-latest-release-tag $distro-dir;
-    my $proc = shell "cd $distro-dir && git log --no-merges --pretty=format:\"\%cn\" $last-tag..HEAD", :out;
+    my $proc = shell "cd $distro-dir && git log --no-merges --pretty=format:\"\%aN\" $last-tag..HEAD", :out;
     my $out = $proc.out.slurp: :close;
     $out.lines.unique;
 }

--- a/release.raku
+++ b/release.raku
@@ -72,7 +72,7 @@ multi MAIN(:$prepare!) {
     for @bumped-distros {
         my $dir = %distro-dirs{$_};
         say "# $_";
-        do {
+        repeat {
             shell "cd $dir && fez review";
         } while prompt("Does this look sane? [yn]") ne "y";
         shell "cd $dir && fez upload";

--- a/release.raku
+++ b/release.raku
@@ -84,7 +84,11 @@ multi MAIN(:$prepare!) {
 
 sub prepare-announcement(@bumped-distros, %versions) {
     my $template = Q:to/EOT/;
-        ## {{DATE}}
+        ## {{DATE}} [[[ADD A SNAPPY TITLE HERE]]]
+
+        [[[ Add a few nice words here! ]]]
+
+        ---
 
         The latest versions of the Cro libraries are:
 

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,12 @@
+{
+    "api": "0",
+    "distros": {
+        "cro": "0.8.10",
+        "Cro::Core": "0.8.10",
+        "Cro::HTTP": "0.8.10",
+        "Cro::TLS": "0.8.10",
+        "Cro::WebApp": "0.9.0",
+        "Cro::WebSocket": "0.8.10"
+    },
+    "docker": "0.8.10"
+}

--- a/versions.json
+++ b/versions.json
@@ -8,5 +8,5 @@
         "Cro::WebApp": "0.9.0",
         "Cro::WebSocket": "0.8.10"
     },
-    "docker": "0.8.10"
+    "oci_image": "0.8.10"
 }


### PR DESCRIPTION
- Generate dependencies that allow updating single distros.
- Allow distros to have differing version numbers.
- Generate a release announcement working off of `Changes` files in the distros and the git committers.
- Add an explanation how to do a release.